### PR TITLE
fix(security): restrict Spring Actuator endpoint exposure (CWE-200)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,8 @@ spring.jpa.open-in-view=false
 spring.messages.basename=messages/messages
 
 # Actuator
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=never
 
 # Logging
 logging.level.org.springframework=INFO


### PR DESCRIPTION
Konvu SAST auto-fix — remediates a Semgrep CWE-200 finding (Spring Boot Actuator fully exposed) confirmed exploitable by Konvu's investigation. Restricts `management.endpoints.web.exposure.include` from `*` to `health,info` and hides health details. Produced end-to-end by the patcheus `--detection` agent: fetch finding + investigation proofs -> plan minimal source fix -> apply scoped to the finding's file -> build/review -> PR. 🤖 Konvu autofix